### PR TITLE
Replace DOCKER_SDK to PROXY_WASM_CPP_SDK in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ The docker image can be used for compiling wasm files.
 Create a directory with your source files and a Makefile:
 
 ```
-DOCKER_SDK=/sdk
+PROXY_WASM_CPP_SDK=/sdk
 
 all: myproject.wasm
 
-include ${DOCKER_SDK}/Makefile.base_lite
+include ${PROXY_WASM_CPP_SDK}/Makefile.base_lite
 ```
 
 Source file (myproject.cc):
@@ -82,11 +82,11 @@ To use a newer/specific version of the SDK (e.g. from the version of Enovy you a
 Here is an example Makefile referencing the SDK at ../envoy/api/wasm/cpp and mounted as 'sdk' in the /work directory:
 
 ```
-DOCKER_SDK=/work/sdk
+PROXY_WASM_CPP_SDK=/work/sdk
 
 all: myproject.wasm
 
-include ${DOCKER_SDK}/Makefile.base_lite
+include ${PROXY_WASM_CPP_SDK}/Makefile.base_lite
 ```
 
 Run docker pointing to Envoy sources in a directory parallel (at the same level) as your project directory:
@@ -100,8 +100,8 @@ docker run -v $PWD:/work -v $PWD/../envoy/api/wasm/cpp:/work/sdk -w /work  wasms
 Abseil (optionally) is built in /root/abseil and can be used. Note that the abseil containers (e.g. absl::flat\_hash\_set) exercise many syscalls which are not supported. Consequantally individual files should be pulled in which are relatively self contained (e.g. strings). Example customized Makefile:
 
 ```
-DOCKER_SDK=/sdk
-CPP_API:=${DOCKER_SDK}
+PROXY_WASM_CPP_SDK=/sdk
+CPP_API:=${PROXY_WASM_CPP_SDK}
 CPP_CONTEXT_LIB = ${CPP_API}/proxy_wasm_intrinsics.cc
 ABSL = /root/abseil-cpp
 ABSL_CPP = ${ABSL}/absl/strings/str_cat.cc ${ABSL}/absl/strings/str_split.cc ${ABSL}/absl/strings/numbers.cc ${ABSL}/absl/strings/ascii.cc
@@ -116,8 +116,8 @@ all: plugin.wasm
 Precompiled abseil libraries are also available, so the above can also be done as:
 
 ```
-DOCKER_SDK=/sdk
-CPP_API:=${DOCKER_SDK}
+PROXY_WASM_CPP_SDK=/sdk
+CPP_API:=${PROXY_WASM_CPP_SDK}
 CPP_CONTEXT_LIB = ${CPP_API}/proxy_wasm_intrinsics.cc
 ABSL = /root/abseil-cpp
 ABSL_LIBS = ${ABSL}/absl/strings/libabsl_strings.a ${ABSL}/absl/strings/libabsl_strings_internal.a  ${ABSL}/absl/strings/libabsl_str_format_internal.a
@@ -134,12 +134,12 @@ all: plugin.wasm
 The compiled files may be owned by root.  To chown them add the follow lines to the Makefile and docker invocation:
 
 ```
-DOCKER_SDK=/sdk
+PROXY_WASM_CPP_SDK=/sdk
 
 all: myproject.wasm
   chown ${uid}.${gid} $^
 
-include ${DOCKER_SDK}/Makefile.base_lite
+include ${PROXY_WASM_CPP_SDK}/Makefile.base_lite
 ```
 
 Invocation file (e.g. build.sh):


### PR DESCRIPTION
After #1 , now we should use `PROXY_WASM_CPP_SDK` instead `DOCKER_SDK`, right....?

Actually by following current README, we cannot build wasm file like below since `Makefile`s use `PROXY_WASM_CPP_SDK` :

```sh
> docker run -v $PWD:/work -w /work  wasmsdk:v2 /build_wasm.sh
Adding directories to PATH:
PATH += /root/emsdk
PATH += /root/emsdk/upstream/emscripten
PATH += /root/emsdk/node/12.9.1_64bit/bin

Setting environment variables:
EMSDK = /root/emsdk
EM_CONFIG = /root/.emscripten
EMSDK_NODE = /root/emsdk/node/12.9.1_64bit/bin/node

make: Nothing to be done for 'all'.
```
