### PR TITLE
Remove WasmHeaderMapType::GrpcCreateInitialMetadata.

### DIFF
--- a/proxy_wasm_common.h
+++ b/proxy_wasm_common.h
@@ -76,16 +76,15 @@ inline std::string toString(WasmResult r) {
 #undef _CASE
 
 enum class WasmHeaderMapType : int32_t {
-  RequestHeaders = 0,   // During the onLog callback these are immutable
-  RequestTrailers = 1,  // During the onLog callback these are immutable
-  ResponseHeaders = 2,  // During the onLog callback these are immutable
-  ResponseTrailers = 3, // During the onLog callback these are immutable
-  GrpcCreateInitialMetadata = 4,
-  GrpcReceiveInitialMetadata = 5,  // Immutable
-  GrpcReceiveTrailingMetadata = 6, // Immutable
-  HttpCallResponseHeaders = 7,     // Immutable
-  HttpCallResponseTrailers = 8,    // Immutable
-  MAX = 8,
+  RequestHeaders = 0,              // During the onLog callback these are immutable
+  RequestTrailers = 1,             // During the onLog callback these are immutable
+  ResponseHeaders = 2,             // During the onLog callback these are immutable
+  ResponseTrailers = 3,            // During the onLog callback these are immutable
+  GrpcReceiveInitialMetadata = 4,  // Immutable
+  GrpcReceiveTrailingMetadata = 5, // Immutable
+  HttpCallResponseHeaders = 6,     // Immutable
+  HttpCallResponseTrailers = 7,    // Immutable
+  MAX = 7,
 };
 enum class WasmBufferType : int32_t {
   HttpRequestBody = 0,       // During the onLog callback these are immutable


### PR DESCRIPTION
Signed-off-by: John Plevyak <jplevyak@gmail.com>