### PR TITLE
Remove onCreateInitialMetadata and move to supplying initial metadata as

### DIFF
--- a/docs/wasm_filter.md
+++ b/docs/wasm_filter.md
@@ -975,7 +975,7 @@ class CallHandler : public GrpcCallHandler<google::protobuf::Empty> {
         /* override onSuccess code */
     }
     /*
-        more callbacks such as onFailure, onCreateInitialMetadata
+        more callbacks such as onFailure
     */
 };
 ```
@@ -1011,15 +1011,6 @@ Called when the async gRPC request fails. No further callbacks will be
 invoked. *status* is returned grpc status. *error\_message* is the gRPC
 status message or empty string if not present.
 
-#### onCreateInitialMetadata
-
-``` {.sourceCode .cpp}
-void onCreateInitialMetadata()
-```
-
-Called when populating the headers to send with initial metadata. TODO:
-how to add metadata?
-
 #### cancel
 
 ``` {.sourceCode .cpp}
@@ -1043,7 +1034,7 @@ class StreamHandler : public GrpcStreamHandler<google::protobuf::Struct, google:
         /* override onReceive code */
     }
     /*
-        more callbacks such as onCreateInitialMetadat, onReceiveTrailingMetadata, onReceive, onRemoteClose
+        more callbacks such as onReceiveTrailingMetadata, onReceive, onRemoteClose
     */
 };
 ```
@@ -1089,15 +1080,6 @@ void reset()
 Close the stream locally and remotely (as needed). No further methods
 may be invoked on the handler object and no further callbacks will be
 invoked.
-
-#### onCreateInitialMetadata
-
-``` {.sourceCode .cpp}
-void onCreateInitialMetadata()
-```
-
-Called when populating the headers to send with initial metadata. TODO:
-how to add initial metadata?
 
 #### onReceiveInitialMetadata
 

--- a/proxy_wasm_api.h
+++ b/proxy_wasm_api.h
@@ -196,7 +196,6 @@ public:
 
   void cancel();
 
-  virtual void onCreateInitialMetadata(uint32_t /* headers */) {}
   virtual void onSuccess(size_t body_size) = 0;
   virtual void onFailure(GrpcStatus status) = 0;
 
@@ -229,7 +228,6 @@ public:
                 // callbacks.
   void reset();
 
-  virtual void onCreateInitialMetadata(uint32_t /* headers */) {}
   virtual void onReceiveInitialMetadata(uint32_t /* headers */) {}
   virtual void onReceiveTrailingMetadata(uint32_t /* trailers */) {}
   virtual void onReceive(size_t body_size) = 0;
@@ -324,7 +322,6 @@ public:
   // Low level HTTP/gRPC interface.
   virtual void onHttpCallResponse(uint32_t token, uint32_t headers, size_t body_size,
                                   uint32_t trailers);
-  virtual void onGrpcCreateInitialMetadata(uint32_t token, uint32_t headers);
   virtual void onGrpcReceiveInitialMetadata(uint32_t token, uint32_t headers);
   virtual void onGrpcReceiveTrailingMetadata(uint32_t token, uint32_t trailers);
   virtual void onGrpcReceive(uint32_t token, size_t body_size);
@@ -338,9 +335,11 @@ public:
   // NB: the message is the response if status == OK and an error message
   // otherwise. Returns false on setup error.
   WasmResult grpcSimpleCall(StringView service, StringView service_name, StringView method_name,
+                            const HeaderStringPairs &initial_metadata,
                             const google::protobuf::MessageLite &request,
                             uint32_t timeout_milliseconds, GrpcSimpleCallCallback callback);
   WasmResult grpcSimpleCall(StringView service, StringView service_name, StringView method_name,
+                            const HeaderStringPairs &initial_metadata,
                             const google::protobuf::MessageLite &request,
                             uint32_t timeout_milliseconds,
                             std::function<void(size_t body_size)> success_callback,
@@ -352,16 +351,18 @@ public:
         failure_callback(status);
       }
     };
-    return grpcSimpleCall(service, service_name, method_name, request, timeout_milliseconds,
-                          callback);
+    return grpcSimpleCall(service, service_name, method_name, initial_metadata, request,
+                          timeout_milliseconds, callback);
   }
   // Returns false on setup error.
   WasmResult grpcCallHandler(StringView service, StringView service_name, StringView method_name,
+                             const HeaderStringPairs &initial_metadata,
                              const google::protobuf::MessageLite &request,
                              uint32_t timeout_milliseconds,
                              std::unique_ptr<GrpcCallHandlerBase> handler);
   // Returns false on setup error.
   WasmResult grpcStreamHandler(StringView service, StringView service_name, StringView method_name,
+                               const HeaderStringPairs &initial_metadata,
                                std::unique_ptr<GrpcStreamHandlerBase> handler);
 
 private:
@@ -1174,19 +1175,28 @@ inline Histogram<Tags...> *Histogram<Tags...>::New(StringView name,
 }
 
 inline WasmResult grpcCall(StringView service, StringView service_name, StringView method_name,
+                           const HeaderStringPairs &initial_metadata,
                            const google::protobuf::MessageLite &request,
                            uint32_t timeout_milliseconds, uint32_t *token_ptr) {
+  void *metadata_ptr = nullptr;
+  size_t metadata_size = 0;
+  MakeHeaderStringPairsBuffer(initial_metadata, &metadata_ptr, &metadata_size);
   std::string serialized_request;
   request.SerializeToString(&serialized_request);
   return proxy_grpc_call(service.data(), service.size(), service_name.data(), service_name.size(),
-                         method_name.data(), method_name.size(), serialized_request.data(),
-                         serialized_request.size(), timeout_milliseconds, token_ptr);
+                         method_name.data(), method_name.size(), metadata_ptr, metadata_size,
+                         serialized_request.data(), serialized_request.size(), timeout_milliseconds,
+                         token_ptr);
 }
 
 inline WasmResult grpcStream(StringView service, StringView service_name, StringView method_name,
-                             uint32_t *token_ptr) {
+                             const HeaderStringPairs &initial_metadata, uint32_t *token_ptr) {
+  void *metadata_ptr = nullptr;
+  size_t metadata_size = 0;
+  MakeHeaderStringPairsBuffer(initial_metadata, &metadata_ptr, &metadata_size);
   return proxy_grpc_stream(service.data(), service.size(), service_name.data(), service_name.size(),
-                           method_name.data(), method_name.size(), token_ptr);
+                           method_name.data(), method_name.size(), metadata_ptr, metadata_size,
+                           token_ptr);
 }
 
 inline WasmResult grpcCancel(uint32_t token) { return proxy_grpc_cancel(token); }
@@ -1221,12 +1231,13 @@ inline void RootContext::onHttpCallResponse(uint32_t token, uint32_t headers, si
 
 inline WasmResult RootContext::grpcSimpleCall(StringView service, StringView service_name,
                                               StringView method_name,
+                                              const HeaderStringPairs &initial_metadata,
                                               const google::protobuf::MessageLite &request,
                                               uint32_t timeout_milliseconds,
                                               Context::GrpcSimpleCallCallback callback) {
   uint32_t token = 0;
-  WasmResult result =
-      grpcCall(service, service_name, method_name, request, timeout_milliseconds, &token);
+  WasmResult result = grpcCall(service, service_name, method_name, initial_metadata, request,
+                               timeout_milliseconds, &token);
   if (result == WasmResult::Ok) {
     asRoot()->simple_grpc_calls_[token] = std::move(callback);
   }
@@ -1259,23 +1270,6 @@ inline void GrpcStreamHandlerBase::send(StringView message, bool end_of_stream) 
     local_close_ = local_close_ || end_of_stream;
     if (local_close_ && remote_close_) {
       context_->grpc_streams_.erase(token_);
-    }
-  }
-}
-
-inline void RootContext::onGrpcCreateInitialMetadata(uint32_t token, uint32_t headers) {
-  {
-    auto it = grpc_calls_.find(token);
-    if (it != grpc_calls_.end()) {
-      it->second->onCreateInitialMetadata(headers);
-      return;
-    }
-  }
-  {
-    auto it = grpc_streams_.find(token);
-    if (it != grpc_streams_.end()) {
-      it->second->onCreateInitialMetadata(headers);
-      return;
     }
   }
 }
@@ -1370,11 +1364,13 @@ inline void RootContext::onGrpcClose(uint32_t token, GrpcStatus status) {
 
 inline WasmResult RootContext::grpcCallHandler(StringView service, StringView service_name,
                                                StringView method_name,
+                                               const HeaderStringPairs &initial_metadata,
                                                const google::protobuf::MessageLite &request,
                                                uint32_t timeout_milliseconds,
                                                std::unique_ptr<GrpcCallHandlerBase> handler) {
   uint32_t token = 0;
-  auto result = grpcCall(service, service_name, method_name, request, timeout_milliseconds, &token);
+  auto result = grpcCall(service, service_name, method_name, initial_metadata, request,
+                         timeout_milliseconds, &token);
   if (result == WasmResult::Ok) {
     handler->token_ = token;
     handler->context_ = this;
@@ -1385,9 +1381,10 @@ inline WasmResult RootContext::grpcCallHandler(StringView service, StringView se
 
 inline WasmResult RootContext::grpcStreamHandler(StringView service, StringView service_name,
                                                  StringView method_name,
+                                                 const HeaderStringPairs &initial_metadata,
                                                  std::unique_ptr<GrpcStreamHandlerBase> handler) {
   uint32_t token = 0;
-  auto result = grpcStream(service, service_name, method_name, &token);
+  auto result = grpcStream(service, service_name, method_name, initial_metadata, &token);
   if (result == WasmResult::Ok) {
     handler->token_ = token;
     handler->context_ = this;

--- a/proxy_wasm_externs.h
+++ b/proxy_wasm_externs.h
@@ -123,11 +123,13 @@ extern "C" WasmResult proxy_http_call(const char *uri_ptr, size_t uri_size, void
 extern "C" WasmResult proxy_grpc_call(const char *service_ptr, size_t service_size,
                                       const char *service_name_ptr, size_t service_name_size,
                                       const char *method_name_ptr, size_t method_name_size,
+                                      size_t initial_metadata_pairs_size, const char *request_ptr,
                                       const char *request_ptr, size_t request_size,
                                       uint32_t timeout_milliseconds, uint32_t *token_ptr);
 extern "C" WasmResult proxy_grpc_stream(const char *service_ptr, size_t service_size,
                                         const char *service_name_ptr, size_t service_name_size,
                                         const char *method_name_ptr, size_t method_name_size,
+                                        size_t initial_metadata_pairs_size, const char *request_ptr,
                                         uint32_t *token_ptr);
 extern "C" WasmResult proxy_grpc_cancel(uint32_t token);
 extern "C" WasmResult proxy_grpc_close(uint32_t token);

--- a/proxy_wasm_intrinsics.cc
+++ b/proxy_wasm_intrinsics.cc
@@ -244,11 +244,6 @@ extern "C" PROXY_WASM_KEEPALIVE void proxy_on_http_call_response(uint32_t contex
 }
 
 extern "C" PROXY_WASM_KEEPALIVE void
-proxy_on_grpc_create_initial_metadata(uint32_t context_id, uint32_t token, uint32_t headers) {
-  getRootContext(context_id)->onGrpcCreateInitialMetadata(token, headers);
-}
-
-extern "C" PROXY_WASM_KEEPALIVE void
 proxy_on_grpc_receive_initial_metadata(uint32_t context_id, uint32_t token, uint32_t headers) {
   getRootContext(context_id)->onGrpcReceiveInitialMetadata(token, headers);
 }


### PR DESCRIPTION
part of the call to create the gRPC stream.

Signed-off-by: John Plevyak <jplevyak@gmail.com>