### PR TITLE
build: not use pre-generated pb.h/cc for bazel build

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -15,34 +15,11 @@ cc_library(
     ],
 )
 
-cc_library(
-    name = "proxy_wasm_intrinsics_lite",
-    srcs = [
-        "proxy_wasm_intrinsics.cc",
-        "proxy_wasm_intrinsics_lite.pb.cc",
-        "struct_lite.pb.cc",
-    ],
-    hdrs = [
-        "proxy_wasm_api.h",
-        "proxy_wasm_common.h",
-        "proxy_wasm_enums.h",
-        "proxy_wasm_externs.h",
-        "proxy_wasm_intrinsics.h",
-        "proxy_wasm_intrinsics_lite.pb.h",
-        "struct_lite.pb.h",
-    ],
-    copts = ["-DPROXY_WASM_PROTOBUF_LITE=1"],
-    visibility = ["//visibility:public"],
-    deps = [
-        "@com_google_protobuf//:protobuf_lite",
-    ],
-)
-
+# Targets for building base library
 cc_library(
     name = "proxy_wasm_intrinsics",
     srcs = [
         "proxy_wasm_intrinsics.cc",
-        "proxy_wasm_intrinsics.pb.cc",
     ],
     hdrs = [
         "proxy_wasm_api.h",
@@ -50,12 +27,67 @@ cc_library(
         "proxy_wasm_enums.h",
         "proxy_wasm_externs.h",
         "proxy_wasm_intrinsics.h",
-        "proxy_wasm_intrinsics.pb.h",
-        "struct_lite.pb.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
+        ":proxy_wasm_intrinsics_cc_proto",
         "@com_google_protobuf//:protobuf",
+    ],
+)
+
+cc_proto_library(
+    name = "proxy_wasm_intrinsics_cc_proto",
+    deps = [":proxy_wasm_intrinsics_proto"],
+)
+
+proto_library(
+    name = "proxy_wasm_intrinsics_proto",
+    srcs = ["proxy_wasm_intrinsics.proto"],
+    deps = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:empty_proto",
+        "@com_google_protobuf//:struct_proto",
+    ],
+)
+
+# Targets for build lite library
+cc_library(
+    name = "proxy_wasm_intrinsics_lite",
+    srcs = [
+        "proxy_wasm_intrinsics.cc",
+    ],
+    hdrs = [
+        "proxy_wasm_api.h",
+        "proxy_wasm_common.h",
+        "proxy_wasm_enums.h",
+        "proxy_wasm_externs.h",
+        "proxy_wasm_intrinsics.h",
+    ],
+    copts = ["-DPROXY_WASM_PROTOBUF_LITE"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":proxy_wasm_intrinsics_lite_cc_proto",
+        "@com_google_protobuf//:protobuf",
+    ],
+)
+
+cc_proto_library(
+    name = "proxy_wasm_intrinsics_lite_cc_proto",
+    deps = [":proxy_wasm_intrinsics_lite_proto"],
+)
+
+proto_library(
+    name = "proxy_wasm_intrinsics_lite_proto",
+    srcs = [
+        "proxy_wasm_intrinsics_lite.proto",
+        "struct_lite.proto",
+    ],
+    deps = [
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:empty_proto",
+        "@com_google_protobuf//:struct_proto",
     ],
 )
 


### PR DESCRIPTION
Extract from #9, this is needed when an outer WORKSPACE is using different version of protobuf, the generated code won't compile around https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/blob/master/proxy_wasm_intrinsics.pb.h#L28