### PR TITLE
Support passing end_of_stream to header callbacks

### DIFF
--- a/proxy_wasm_externs.h
+++ b/proxy_wasm_externs.h
@@ -164,11 +164,15 @@ extern "C" void proxy_on_queue_ready(uint32_t root_context_id, uint32_t token);
 // Stream calls.
 extern "C" void proxy_on_context_create(uint32_t context_id, uint32_t parent_context_id);
 extern "C" FilterHeadersStatus proxy_on_request_headers(uint32_t context_id, uint32_t headers);
+extern "C" FilterHeadersStatus proxy_on_request_headers_ext(uint32_t context_id, uint32_t headers,
+                                                            uint32_t end_of_stream);
 extern "C" FilterDataStatus proxy_on_request_body(uint32_t context_id, uint32_t body_buffer_length,
                                                   uint32_t end_of_stream);
 extern "C" FilterTrailersStatus proxy_on_request_trailers(uint32_t context_id, uint32_t trailers);
 extern "C" FilterMetadataStatus proxy_on_request_metadata(uint32_t context_id, uint32_t nelements);
 extern "C" FilterHeadersStatus proxy_on_response_headers(uint32_t context_id, uint32_t headers);
+extern "C" FilterHeadersStatus proxy_on_response_headers_ext(uint32_t context_id, uint32_t headers,
+                                                             uint32_t end_of_stream);
 extern "C" FilterDataStatus proxy_on_response_body(uint32_t context_id, uint32_t body_buffer_length,
                                                    uint32_t end_of_stream);
 extern "C" FilterTrailersStatus proxy_on_response_trailers(uint32_t context_id, uint32_t trailers);


### PR DESCRIPTION
Do this in a backwardly-compatible way by creating two new ABI
functions:

on_request_headers_ext
on_response_headers_ext

Each one takes an additional Word parameter at the end which
carries the value of the "end_of_stream" flag from Envoy.
The proxy_wasm_cpp_host code will first check for the existence
of the "ext" version of a function and fall back to the original
version if it is not found.

If you like this approach, then I'll submit the matching PR to fix this in the "host" repo.

If you would prefer to simply add the additional flag to the existing function signatures,
then I'm happy to do that as well. It would be an incompatible change to the ABI, although I think that one of those was already made when the function to get the configuration data was removed.

Signed-off-by: Gregory Brail <gregbrail@google.com>