### PR TITLE
Enable onForeignFunction and proxy-specific extensions to the ABI.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,7 +4,10 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "api_lib",
-    hdrs = ["proxy_wasm_api.h"],
+    hdrs = [
+        "proxy_wasm_api.h",
+        "proxy_wasm_externs.h",
+    ],
 )
 
 cc_library(

--- a/proxy_wasm_api.h
+++ b/proxy_wasm_api.h
@@ -19,6 +19,8 @@
  * Intrinsic high-level support functions available to WASM modules.
  */
 // NOLINT(namespace-envoy)
+#pragma once
+
 #include <functional>
 #include <string>
 #include <tuple>
@@ -283,6 +285,8 @@ public:
   // Called to indicate that no more calls will come and this context is being
   // deleted.
   virtual void onDelete() {} // Called when the stream or VM is being deleted.
+  // Called when a foreign function event arrives.
+  virtual void onForeignFunction(uint32_t /* foreign_function_id */, uint32_t /* data_size */) {}
 
   using HttpCallCallback =
       std::function<void(uint32_t, size_t, uint32_t)>; // headers, body_size, trailers

--- a/proxy_wasm_common.h
+++ b/proxy_wasm_common.h
@@ -19,7 +19,6 @@
  * Common enumerations available to WASM modules and shared with sandbox.
  */
 // NOLINT(namespace-envoy)
-
 #pragma once
 
 #include <string>
@@ -95,7 +94,8 @@ enum class WasmBufferType : int32_t {
   GrpcReceiveBuffer = 5,     // Immutable
   VmConfiguration = 6,       // Immutable
   PluginConfiguration = 7,   // Immutable
-  MAX = 7,
+  CallData = 8,              // Immutable
+  MAX = 8,
 };
 enum class WasmBufferFlags : int32_t {
   // These must be powers of 2.

--- a/proxy_wasm_enums.h
+++ b/proxy_wasm_enums.h
@@ -19,7 +19,6 @@
  * Intrinsic enumerations available to WASM modules.
  */
 // NOLINT(namespace-envoy)
-
 #pragma once
 
 enum class LogLevel : int32_t { trace, debug, info, warn, error, critical, Max = critical };

--- a/proxy_wasm_externs.h
+++ b/proxy_wasm_externs.h
@@ -19,7 +19,6 @@
  * Proxy-WASM ABI.
  */
 // NOLINT(namespace-envoy)
-
 #pragma once
 
 #include <stddef.h>
@@ -39,7 +38,7 @@ extern "C" WasmResult proxy_get_status(uint32_t *status_code_ptr, const char **m
 // Logging
 extern "C" WasmResult proxy_log(LogLevel level, const char *logMessage, size_t messageSize);
 
-// Timer (must be called from a root context, e.g. onStart, onTick).
+// Timer (will be set for the root context, e.g. onStart, onTick).
 extern "C" WasmResult proxy_set_tick_period_milliseconds(uint32_t millisecond);
 
 // Time
@@ -159,6 +158,8 @@ extern "C" uint32_t proxy_validate_configuration(uint32_t root_context_id,
                                                  uint32_t configuration_size);
 extern "C" uint32_t proxy_on_configure(uint32_t root_context_id, uint32_t configuration_size);
 extern "C" void proxy_on_tick(uint32_t root_context_id);
+extern "C" void proxy_on_foreign_function(uint32_t root_context_id, uint32_t function_id,
+                                          uint32_t data_size);
 extern "C" void proxy_on_queue_ready(uint32_t root_context_id, uint32_t token);
 
 // Stream calls.

--- a/proxy_wasm_intrinsics.cc
+++ b/proxy_wasm_intrinsics.cc
@@ -266,3 +266,8 @@ extern "C" PROXY_WASM_KEEPALIVE void proxy_on_grpc_close(uint32_t context_id, ui
 extern "C" PROXY_WASM_KEEPALIVE void proxy_on_queue_ready(uint32_t context_id, uint32_t token) {
   getRootContext(context_id)->onQueueReady(token);
 }
+
+extern "C" PROXY_WASM_KEEPALIVE void
+proxy_on_foreign_function(uint32_t context_id, uint32_t foreign_function_id, uint32_t data_size) {
+  getContextBase(context_id)->onForeignFunction(foreign_function_id, data_size);
+}

--- a/proxy_wasm_intrinsics.h
+++ b/proxy_wasm_intrinsics.h
@@ -19,7 +19,6 @@
  * API Available to WASM modules.
  */
 // NOLINT(namespace-envoy)
-
 #pragma once
 
 #ifndef PROXY_WASM_KEEPALIVE
@@ -38,7 +37,6 @@ template <typename T> using Optional = std::optional<T>;
 
 #include "proxy_wasm_enums.h"
 #include "proxy_wasm_common.h"
-#include "proxy_wasm_enums.h"
 #include "proxy_wasm_externs.h"
 #ifdef PROXY_WASM_PROTOBUF_FULL
 #define PROXY_WASM_PROTOBUF 1

--- a/proxy_wasm_intrinsics_full.h
+++ b/proxy_wasm_intrinsics_full.h
@@ -19,7 +19,7 @@
  * API Available to WASM modules.
  */
 // NOLINT(namespace-envoy)
-
 #pragma once
+
 #define PROXY_WASM_PROTOBUF_FULL 1
 #include "proxy_wasm_intrinsics.h"

--- a/proxy_wasm_intrinsics_lite.h
+++ b/proxy_wasm_intrinsics_lite.h
@@ -19,7 +19,7 @@
  * API Available to WASM modules.
  */
 // NOLINT(namespace-envoy)
-
 #pragma once
+
 #define PROXY_WASM_PROTOBUF_LITE 1
 #include "proxy_wasm_intrinsics.h"


### PR DESCRIPTION
Signed-off-by: John Plevyak <jplevyak@gmail.com>