### PR TITLE
Pass end_of_stream to header callbacks.

### DIFF
--- a/proxy_wasm_api.h
+++ b/proxy_wasm_api.h
@@ -310,7 +310,7 @@ public:
   // Called once when the VM loads and once when each hook loads and whenever
   // configuration changes. Returns false if the configuration is invalid.
   virtual bool onConfigure(size_t /* configuration_size */) { return true; }
-  // Called when each hook loads.  Returns false if the configuration is
+  // Called when each hook loads. Returns false if the configuration is
   // invalid.
   virtual bool onStart(size_t /* vm_configuration_size */) { return true; }
   // Called when the timer goes off.
@@ -329,7 +329,7 @@ public:
   virtual void onGrpcReceive(uint32_t token, size_t body_size);
   virtual void onGrpcClose(uint32_t token, GrpcStatus status);
 
-  // Default high level HTTP/gRPC interface.  NB: overriding the low level
+  // Default high level HTTP/gRPC interface. NB: overriding the low level
   // interface will disable this interface. Returns false on setup error.
   WasmResult httpCall(StringView uri, const HeaderStringPairs &request_headers,
                       StringView request_body, const HeaderStringPairs &request_trailers,
@@ -417,7 +417,7 @@ private:
 
 RootContext *getRoot(StringView root_id);
 
-// Context for a stream.  The distinguished context id == 0 is used for
+// Context for a stream. The distinguished context id == 0 is used for
 // non-stream calls.
 class Context : public ContextBase {
 public:
@@ -435,7 +435,9 @@ public:
   virtual void onDownstreamConnectionClose(PeerType) {}
   virtual void onUpstreamConnectionClose(PeerType) {}
 
-  virtual FilterHeadersStatus onRequestHeaders(uint32_t) { return FilterHeadersStatus::Continue; }
+  virtual FilterHeadersStatus onRequestHeaders(uint32_t, bool) {
+    return FilterHeadersStatus::Continue;
+  }
   virtual FilterMetadataStatus onRequestMetadata(uint32_t) {
     return FilterMetadataStatus::Continue;
   }
@@ -446,7 +448,9 @@ public:
   virtual FilterTrailersStatus onRequestTrailers(uint32_t) {
     return FilterTrailersStatus::Continue;
   }
-  virtual FilterHeadersStatus onResponseHeaders(uint32_t) { return FilterHeadersStatus::Continue; }
+  virtual FilterHeadersStatus onResponseHeaders(uint32_t, bool) {
+    return FilterHeadersStatus::Continue;
+  }
   virtual FilterMetadataStatus onResponseMetadata(uint32_t) {
     return FilterMetadataStatus::Continue;
   }

--- a/proxy_wasm_externs.h
+++ b/proxy_wasm_externs.h
@@ -163,12 +163,14 @@ extern "C" void proxy_on_queue_ready(uint32_t root_context_id, uint32_t token);
 
 // Stream calls.
 extern "C" void proxy_on_context_create(uint32_t context_id, uint32_t parent_context_id);
-extern "C" FilterHeadersStatus proxy_on_request_headers(uint32_t context_id, uint32_t headers);
+extern "C" FilterHeadersStatus proxy_on_request_headers(uint32_t context_id, uint32_t headers,
+                                                        uint32_t end_of_stream);
 extern "C" FilterDataStatus proxy_on_request_body(uint32_t context_id, uint32_t body_buffer_length,
                                                   uint32_t end_of_stream);
 extern "C" FilterTrailersStatus proxy_on_request_trailers(uint32_t context_id, uint32_t trailers);
 extern "C" FilterMetadataStatus proxy_on_request_metadata(uint32_t context_id, uint32_t nelements);
-extern "C" FilterHeadersStatus proxy_on_response_headers(uint32_t context_id, uint32_t headers);
+extern "C" FilterHeadersStatus proxy_on_response_headers(uint32_t context_id, uint32_t headers,
+                                                         uint32_t end_of_stream);
 extern "C" FilterDataStatus proxy_on_response_body(uint32_t context_id, uint32_t body_buffer_length,
                                                    uint32_t end_of_stream);
 extern "C" FilterTrailersStatus proxy_on_response_trailers(uint32_t context_id, uint32_t trailers);

--- a/proxy_wasm_intrinsics.cc
+++ b/proxy_wasm_intrinsics.cc
@@ -178,9 +178,9 @@ extern "C" PROXY_WASM_KEEPALIVE void proxy_on_upstream_connection_close(uint32_t
   return getContext(context_id)->onUpstreamConnectionClose(static_cast<PeerType>(peer_type));
 }
 
-extern "C" PROXY_WASM_KEEPALIVE FilterHeadersStatus proxy_on_request_headers(uint32_t context_id,
-                                                                             uint32_t headers) {
-  return getContext(context_id)->onRequestHeaders(headers);
+extern "C" PROXY_WASM_KEEPALIVE FilterHeadersStatus
+proxy_on_request_headers(uint32_t context_id, uint32_t headers, uint32_t end_of_stream) {
+  return getContext(context_id)->onRequestHeaders(headers, end_of_stream != 0);
 }
 
 extern "C" PROXY_WASM_KEEPALIVE FilterMetadataStatus proxy_on_request_metadata(uint32_t context_id,
@@ -200,9 +200,9 @@ extern "C" PROXY_WASM_KEEPALIVE FilterTrailersStatus proxy_on_request_trailers(u
   return getContext(context_id)->onRequestTrailers(trailers);
 }
 
-extern "C" PROXY_WASM_KEEPALIVE FilterHeadersStatus proxy_on_response_headers(uint32_t context_id,
-                                                                              uint32_t headers) {
-  return getContext(context_id)->onResponseHeaders(headers);
+extern "C" PROXY_WASM_KEEPALIVE FilterHeadersStatus
+proxy_on_response_headers(uint32_t context_id, uint32_t headers, uint32_t end_of_stream) {
+  return getContext(context_id)->onResponseHeaders(headers, end_of_stream != 0);
 }
 
 extern "C" PROXY_WASM_KEEPALIVE FilterMetadataStatus proxy_on_response_metadata(uint32_t context_id,


### PR DESCRIPTION
This adds the same end_of_stream flag to the on_request_headers
and on_response_headers callbacks that Envoy makes for non-WASM filters.
This way it is possible to write a filter that can operate on the
request or response body but still be resilient if no body is present.

This is an incompatible change -- WASM filters will need to be rebuilt with the additional flag on the proxy_on_request_headers and proxy_on_response_headers flags added.

I'll submit the matching PRs for the other two repos once this one is merged.

Signed-off-by: Gregory Brail <gregbrail@google.com>