### PR TITLE
fix sendLocalResponse set response header and free ptr

### DIFF
--- a/proxy_wasm_api.h
+++ b/proxy_wasm_api.h
@@ -605,9 +605,9 @@ inline WasmResult sendLocalResponse(uint32_t response_code, StringView response_
   const char *ptr = nullptr;
   size_t size = 0;
   exportPairs(additional_response_headers, &ptr, &size);
-  WasmResult result = proxy_send_local_response(response_code, response_code_details.data(),
-      response_code_details.size(), body.data(), body.size(), ptr,
-      size, static_cast<uint32_t>(grpc_status));
+  WasmResult result = proxy_send_local_response(
+      response_code, response_code_details.data(), response_code_details.size(), body.data(),
+      body.size(), ptr, size, static_cast<uint32_t>(grpc_status));
   ::free(const_cast<char *>(ptr));
   return result;
 }

--- a/proxy_wasm_api.h
+++ b/proxy_wasm_api.h
@@ -172,6 +172,7 @@ template <typename Pairs> void exportPairs(const Pairs &pairs, const char **ptr,
   char *buffer = static_cast<char *>(::malloc(size));
   marshalPairs(pairs, buffer);
   *size_ptr = size;
+  *ptr = buffer;
 }
 
 struct PairHash {
@@ -604,9 +605,11 @@ inline WasmResult sendLocalResponse(uint32_t response_code, StringView response_
   const char *ptr = nullptr;
   size_t size = 0;
   exportPairs(additional_response_headers, &ptr, &size);
-  return proxy_send_local_response(response_code, response_code_details.data(),
+  WasmResult result = proxy_send_local_response(response_code, response_code_details.data(),
                                    response_code_details.size(), body.data(), body.size(), ptr,
                                    size, static_cast<uint32_t>(grpc_status));
+  ::free(const_cast<char *>(ptr));
+  return result;
 }
 
 // SharedData

--- a/proxy_wasm_api.h
+++ b/proxy_wasm_api.h
@@ -606,8 +606,8 @@ inline WasmResult sendLocalResponse(uint32_t response_code, StringView response_
   size_t size = 0;
   exportPairs(additional_response_headers, &ptr, &size);
   WasmResult result = proxy_send_local_response(response_code, response_code_details.data(),
-                                   response_code_details.size(), body.data(), body.size(), ptr,
-                                   size, static_cast<uint32_t>(grpc_status));
+      response_code_details.size(), body.data(), body.size(), ptr,
+      size, static_cast<uint32_t>(grpc_status));
   ::free(const_cast<char *>(ptr));
   return result;
 }


### PR DESCRIPTION
1、in exportPairs,  "ptr" should  set with  "buffer".
2、in sendLocalResponse, free "ptr" after proxy_send_local_response called.