### PR TITLE
Bump Proxy-Wasm ABI version to 0.2.0.

### DIFF
--- a/proxy_wasm_intrinsics.cc
+++ b/proxy_wasm_intrinsics.cc
@@ -17,7 +17,7 @@
 #include "proxy_wasm_intrinsics.h"
 
 // Required Proxy-Wasm ABI version.
-extern "C" PROXY_WASM_KEEPALIVE void proxy_abi_version_0_1_0() {}
+extern "C" PROXY_WASM_KEEPALIVE void proxy_abi_version_0_2_0() {}
 
 static std::unordered_map<std::string, RootFactory> *root_factories = nullptr;
 static std::unordered_map<std::string, ContextFactory> *context_factories = nullptr;


### PR DESCRIPTION
Signed-off-by: Piotr Sikora <piotrsikora@google.com>