### PR TITLE
Add support for proxy_get_log_level

### DIFF
--- a/proxy_wasm_api.h
+++ b/proxy_wasm_api.h
@@ -289,6 +289,9 @@ public:
   // Called when a foreign function event arrives.
   virtual void onForeignFunction(uint32_t /* foreign_function_id */, uint32_t /* data_size */) {}
 
+  // Return the log level configured for the "wasm" logger in the host
+  WasmResult getLogLevel(LogLevel *level) { return proxy_get_log_level(level); }
+
   using HttpCallCallback =
       std::function<void(uint32_t, size_t, uint32_t)>; // headers, body_size, trailers
   using GrpcSimpleCallCallback = std::function<void(GrpcStatus status, size_t body_size)>;

--- a/proxy_wasm_externs.h
+++ b/proxy_wasm_externs.h
@@ -37,6 +37,7 @@ extern "C" WasmResult proxy_get_status(uint32_t *status_code_ptr, const char **m
 
 // Logging
 extern "C" WasmResult proxy_log(LogLevel level, const char *logMessage, size_t messageSize);
+extern "C" WasmResult proxy_get_log_level(LogLevel *level);
 
 // Timer (will be set for the root context, e.g. onStart, onTick).
 extern "C" WasmResult proxy_set_tick_period_milliseconds(uint32_t millisecond);

--- a/proxy_wasm_intrinsics.js
+++ b/proxy_wasm_intrinsics.js
@@ -18,6 +18,7 @@
 mergeInto(LibraryManager.library, {
   proxy_get_configuration: function() {},
   proxy_log: function() {},
+  proxy_get_log_level: function() {},
   proxy_set_tick_period_milliseconds: function() {},
   proxy_get_current_time_nanoseconds: function() {},
   proxy_get_status: function() {},


### PR DESCRIPTION
This lets the WASM code determine the log level set for the
"wasm" logger on the proxy host, which can be used to optimize
when log messages are generated.

Signed-off-by: Gregory Brail <gregbrail@google.com>