### PR TITLE
Add include <cstring> for clang-tidy.

### DIFF
--- a/proxy_wasm_api.h
+++ b/proxy_wasm_api.h
@@ -21,6 +21,7 @@
 // NOLINT(namespace-envoy)
 #pragma once
 
+#include <cstring>
 #include <functional>
 #include <memory>
 #include <string>


### PR DESCRIPTION
Signed-off-by: John Plevyak <jplevyak@gmail.com>