### PR TITLE
Move onLog to ContextBase since it can be called on a Root Context.

### DIFF
--- a/proxy_wasm_api.h
+++ b/proxy_wasm_api.h
@@ -285,6 +285,9 @@ public:
 
   virtual void onCreate() {}
   virtual bool onDoneBase() = 0;
+  // Called on Stream Context after onDone when logging is requested or called on Root Context
+  // if so requested.
+  virtual void onLog() {}
   // Called to indicate that no more calls will come and this context is being
   // deleted.
   virtual void onDelete() {} // Called when the stream or VM is being deleted.
@@ -476,7 +479,6 @@ public:
     return FilterTrailersStatus::Continue;
   }
   virtual void onDone() {} // Called when the stream has completed.
-  virtual void onLog() {}  // Called after onDone when logging is requested.
 
 private:
   // For stream Contexts, onDone always returns true.

--- a/proxy_wasm_intrinsics.cc
+++ b/proxy_wasm_intrinsics.cc
@@ -227,7 +227,7 @@ extern "C" PROXY_WASM_KEEPALIVE uint32_t proxy_on_done(uint32_t context_id) {
 }
 
 extern "C" PROXY_WASM_KEEPALIVE void proxy_on_log(uint32_t context_id) {
-  getContext(context_id)->onLog();
+  getContextBase(context_id)->onLog();
 }
 
 extern "C" PROXY_WASM_KEEPALIVE void proxy_on_delete(uint32_t context_id) {


### PR DESCRIPTION
Signed-off-by: John Plevyak <jplevyak@gmail.com>