### PR TITLE
bash: Small bash fix for empty args

### DIFF
--- a/toolchain/emcc.sh
+++ b/toolchain/emcc.sh
@@ -25,7 +25,7 @@ emcc -s EMIT_EMSCRIPTEN_METADATA=1 -s STANDALONE_WASM=1 -s EXPORTED_FUNCTIONS=['
 
 for arg in "$@"
 do
-    if [ ${arg: -2} == ".d" ]; then
+    if [ "${arg: -2}" == ".d" ]; then
         echo Fixing $arg
         sed -e 's%[^ ]*/external/emscripten_toolchain/upstream/emscripten/system/%external/emscripten_toolchain/upstream/emscripten/system/%' $arg > $arg.tmp
         mv $arg.tmp $arg


### PR DESCRIPTION
When compiling a wasm file  using the sdk, i am seeing a bash error

not sure the exact cause, but the `emcc.sh` script is being called with an empty arg i think

it creates an error like so:

https://travis-ci.org/github/phlax/bazeldev/builds/736781031#L922

this should prevent the error
