### PR TITLE
Update proxy_wasm_api.h

### DIFF
--- a/proxy_wasm_api.h
+++ b/proxy_wasm_api.h
@@ -1575,6 +1575,6 @@ inline uint64_t getCurrentTimeNanoseconds() {
   return t;
 }
 
-inline void setTickPeriodMilliseconds(uint32_t millisecond){ proxy_set_tick_period_milliseconds(millisecond); }
+inline void setTickPeriodMilliseconds(uint32_t millisecond) { proxy_set_tick_period_milliseconds(millisecond); }
 
 inline void RootContext::done() { proxy_done(); }

--- a/proxy_wasm_api.h
+++ b/proxy_wasm_api.h
@@ -1575,4 +1575,6 @@ inline uint64_t getCurrentTimeNanoseconds() {
   return t;
 }
 
+inline void setTickPeriodMilliseconds(uint32_t millisecond){ proxy_set_tick_period_milliseconds(millisecond); }
+
 inline void RootContext::done() { proxy_done(); }

--- a/proxy_wasm_api.h
+++ b/proxy_wasm_api.h
@@ -1575,6 +1575,8 @@ inline uint64_t getCurrentTimeNanoseconds() {
   return t;
 }
 
-inline void setTickPeriodMilliseconds(uint32_t millisecond) { proxy_set_tick_period_milliseconds(millisecond); }
+inline void setTickPeriodMilliseconds(uint32_t millisecond) {
+  proxy_set_tick_period_milliseconds(millisecond); 
+}
 
 inline void RootContext::done() { proxy_done(); }


### PR DESCRIPTION
Add setTickPeriodMilliseconds( uint32_t millisecond ) to api.h

As doc tells:

![image](https://user-images.githubusercontent.com/48784001/115652799-7f212a80-a360-11eb-9272-e34dc5f28c6c.png)

We support setTickPeriodMilliseconds API but actually not impl in api.h.



