### PR TITLE
Impl  getRequest/ResponseBodyBufferBytes( ) in proxy_wasm_api.h

### DIFF
--- a/proxy_wasm_api.h
+++ b/proxy_wasm_api.h
@@ -905,6 +905,14 @@ inline WasmResult setBuffer(WasmBufferType type, size_t start, size_t length, st
   return result;
 }
 
+inline WasmDataPtr getResponseBodyBufferBytes(size_t start, size_t length){
+  return getBufferBytes(WasmBufferType::HttpResponseBody,start,length);
+}
+
+inline WasmDataPtr getRequestBodyBufferBytes(size_t start, size_t length){
+  return getBufferBytes(WasmBufferType::HttpRequestBody,start,length);
+}
+
 // HTTP
 
 inline void MakeHeaderStringPairsBuffer(const HeaderStringPairs &headers, void **buffer_ptr,

--- a/proxy_wasm_api.h
+++ b/proxy_wasm_api.h
@@ -905,11 +905,11 @@ inline WasmResult setBuffer(WasmBufferType type, size_t start, size_t length, st
   return result;
 }
 
-inline WasmDataPtr getResponseBodyBufferBytes(size_t start, size_t length){
+inline WasmDataPtr getResponseBodyBufferBytes(size_t start, size_t length) {
   return getBufferBytes(WasmBufferType::HttpResponseBody, start, length);
 }
 
-inline WasmDataPtr getRequestBodyBufferBytes(size_t start, size_t length){
+inline WasmDataPtr getRequestBodyBufferBytes(size_t start, size_t length) {
   return getBufferBytes(WasmBufferType::HttpRequestBody, start, length);
 }
 

--- a/proxy_wasm_api.h
+++ b/proxy_wasm_api.h
@@ -906,11 +906,11 @@ inline WasmResult setBuffer(WasmBufferType type, size_t start, size_t length, st
 }
 
 inline WasmDataPtr getResponseBodyBufferBytes(size_t start, size_t length){
-  return getBufferBytes(WasmBufferType::HttpResponseBody,start,length);
+  return getBufferBytes(WasmBufferType::HttpResponseBody, start, length);
 }
 
 inline WasmDataPtr getRequestBodyBufferBytes(size_t start, size_t length){
-  return getBufferBytes(WasmBufferType::HttpRequestBody,start,length);
+  return getBufferBytes(WasmBufferType::HttpRequestBody, start, length);
 }
 
 // HTTP


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/48784001/115708884-1f983e80-a3a3-11eb-836f-4b61e8b81252.png)
As doc tells, we should support getRequest/ResponseBodyBufferBytes( ), but actually but impl, so I give PR to fix this.