### PR TITLE
Fix typos in Bazel function names.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,13 +1,13 @@
 workspace(name = "proxy_wasm_cpp_sdk")
 
-load("@proxy_wasm_cpp_sdk//bazel:repositories.bzl", "proxy_wasm_cpp_host_repositories")
+load("@proxy_wasm_cpp_sdk//bazel:repositories.bzl", "proxy_wasm_cpp_sdk_repositories")
 
-proxy_wasm_cpp_host_repositories()
+proxy_wasm_cpp_sdk_repositories()
 
-load("@proxy_wasm_cpp_sdk//bazel:dependencies.bzl", "proxy_wasm_cpp_host_dependencies")
+load("@proxy_wasm_cpp_sdk//bazel:dependencies.bzl", "proxy_wasm_cpp_sdk_dependencies")
 
-proxy_wasm_cpp_host_dependencies()
+proxy_wasm_cpp_sdk_dependencies()
 
-load("@proxy_wasm_cpp_sdk//bazel:dependencies_extra.bzl", "proxy_wasm_cpp_host_dependencies_extra")
+load("@proxy_wasm_cpp_sdk//bazel:dependencies_extra.bzl", "proxy_wasm_cpp_sdk_dependencies_extra")
 
-proxy_wasm_cpp_host_dependencies_extra()
+proxy_wasm_cpp_sdk_dependencies_extra()

--- a/bazel/dependencies.bzl
+++ b/bazel/dependencies.bzl
@@ -15,7 +15,7 @@
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 load("@emsdk//:deps.bzl", emsdk_deps = "deps")
 
-# Requires proxy_wasm_cpp_host_repositories() to be loaded first.
-def proxy_wasm_cpp_host_dependencies():
+# Requires proxy_wasm_cpp_sdk_repositories() to be loaded first.
+def proxy_wasm_cpp_sdk_dependencies():
     protobuf_deps()
     emsdk_deps()

--- a/bazel/dependencies_extra.bzl
+++ b/bazel/dependencies_extra.bzl
@@ -14,6 +14,6 @@
 
 load("@emsdk//:emscripten_deps.bzl", "emscripten_deps")
 
-# Requires proxy_wasm_cpp_host_dependencies() to be loaded first.
-def proxy_wasm_cpp_host_dependencies_extra():
+# Requires proxy_wasm_cpp_sdk_dependencies() to be loaded first.
+def proxy_wasm_cpp_sdk_dependencies_extra():
     emscripten_deps()

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -15,7 +15,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
-def proxy_wasm_cpp_host_repositories():
+def proxy_wasm_cpp_sdk_repositories():
     maybe(
         http_archive,
         name = "emsdk",


### PR DESCRIPTION
Just change the name of bazel functions to use "sdk".

Signed-off-by: Ingwon Song <igsong@google.com>