### PR TITLE
Add <optional> include to proxy_asm_api.h.

### DIFF
--- a/proxy_wasm_api.h
+++ b/proxy_wasm_api.h
@@ -28,6 +28,7 @@
 #include <cstring>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <unordered_map>


### PR DESCRIPTION
proxy_asm_api.h references `std::optional`—see, for example, `getProperty`—but was missing the include for it.