### PR TITLE
Fix CODEOWNERS format

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,1 @@
-* @PiotrSikora
-* @martijneken
-* @mpwarres
+* @PiotrSikora @martijneken @mpwarres


### PR DESCRIPTION
Same as proxy-wasm/proxy-wasm-cpp-host#395, rationale [here](https://github.com/proxy-wasm/proxy-wasm-cpp-host/pull/392#issuecomment-2081956690).