### PR TITLE
chore: update build action to use actions/cache@v4

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -67,7 +67,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Mount bazel cache
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: "/home/runner/.cache/bazel"
         key: bazel


### PR DESCRIPTION
actions/cache@v1 is no longer supported:
https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down