### PR TITLE
Add BCR configuration and workflow for Bazel Central Registry publishing

### DIFF
--- a/.bcr/README.md
+++ b/.bcr/README.md
@@ -1,0 +1,92 @@
+# Bazel Central Registry (BCR) Publishing
+
+This directory contains template files used to publish `proxy-wasm-cpp-sdk` to the [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry).
+
+## Overview
+
+The BCR publishing automation uses these template files to create new entries in the Bazel Central Registry when a new release is tagged. This allows users to consume this SDK as a Bazel module using `bzlmod`.
+
+## Files
+
+### metadata.template.json
+
+Contains metadata about the module including:
+- Homepage and repository URL
+- Maintainer information (populated from CODEOWNERS)
+- Version tracking
+
+**Note**: The maintainer information is populated from the CODEOWNERS file. The `versions` field is automatically updated by the publishing workflow.
+
+### source.template.json
+
+Defines how to fetch the source code for a release:
+- Source archive URL pattern
+- Archive integrity hash (filled automatically)
+- Strip prefix for archive extraction
+
+### presubmit.yml
+
+Defines tests that run in BCR CI to validate each release:
+- Test targets to build/run
+- Bazel versions to test against
+- Platforms to test on
+
+## Publishing Process
+
+When a new tag is pushed (e.g., `v1.0.0`):
+
+1. The GitHub Actions workflow (`.github/workflows/publish-to-bcr.yml`) is automatically triggered
+2. The workflow uses these template files to generate a BCR entry
+3. A pull request is opened against https://github.com/bazelbuild/bazel-central-registry
+4. Once approved by BCR maintainers, the PR is merged to publish the new version
+
+## Maintainer Instructions
+
+### Prerequisites
+
+1. **Create a Personal Access Token (PAT)**:
+   - Go to GitHub Settings > Developer settings > Personal access tokens > Tokens (classic)
+   - Click "Generate new token (classic)"
+   - Name it something like "BCR Publish Token"
+   - Select scopes: `repo` (Full control of private repositories) and `workflow` (Update GitHub Action workflows)
+   - Generate and copy the token
+
+2. **Add the token as a repository secret**:
+   - Go to your repository Settings > Secrets and variables > Actions
+   - Click "New repository secret"
+   - Name: `BCR_PUBLISH_TOKEN`
+   - Value: Paste your PAT
+   - Click "Add secret"
+
+### Creating a Release
+
+1. **Tag a new version**:
+   ```bash
+   git tag -a v1.0.0 -m "Release v1.0.0"
+   git push origin v1.0.0
+   ```
+
+   This will automatically trigger the "Publish to BCR" workflow.
+
+2. **Monitor the publish workflow**:
+   - Go to Actions tab in your repository
+   - Find the "Publish to BCR" workflow run
+   - Ensure it completes successfully
+   - Check https://github.com/bazelbuild/bazel-central-registry for the new pull request
+
+3. **Complete the BCR submission**:
+   - Review the pull request in the BCR
+   - Wait for BCR maintainers to review and merge
+
+### Troubleshooting
+
+- **Workflow fails with authentication error**: Check that `BCR_PUBLISH_TOKEN` secret is set correctly
+- **Workflow fails to create PR**: Ensure you have a fork of bazel-central-registry configured in the workflow
+- **BCR CI fails**: Review the `presubmit.yml` configuration and ensure test targets are correct
+- **Integrity hash mismatch**: Ensure the release archive is created correctly and hasn't been modified
+
+## References
+
+- [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry)
+- [publish-to-bcr documentation](https://github.com/bazel-contrib/publish-to-bcr)
+- [Bzlmod User Guide](https://bazel.build/docs/bzlmod)

--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -1,0 +1,28 @@
+{
+  "homepage": "https://github.com/proxy-wasm/proxy-wasm-cpp-sdk",
+  "maintainers": [
+    {
+      "name": "Piotr Sikora",
+      "email": "piotrsikora@google.com",
+      "github": "PiotrSikora",
+      "github_user_id": 190297
+    },
+    {
+      "name": "Martijn Eken",
+      "email": "martijneken@google.com",
+      "github": "martijneken",
+      "github_user_id": 2081190
+    },
+    {
+      "name": "Michael Warres",
+      "email": "mpwarres@google.com",
+      "github": "mpwarres",
+      "github_user_id": 156047
+    }
+  ],
+  "repository": [
+    "github:proxy-wasm/proxy-wasm-cpp-sdk"
+  ],
+  "versions": [],
+  "yanked_versions": {}
+}

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+matrix:
+  platform: ["debian11", "macos", "ubuntu2204"]
+  bazel: [6.x, 7.x, 8.x]
+tasks:
+  verify_targets:
+    name: "Build example WebAssembly modules"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+      - "@proxy-wasm-cpp-sdk//..."

--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,0 +1,5 @@
+{
+  "integrity": "",
+  "strip_prefix": "{REPO}-{VERSION}",
+  "url": "https://github.com/{OWNER}/{REPO}/archive/refs/tags/{TAG}.tar.gz"
+}

--- a/.github/workflows/publish-to-bcr.yml
+++ b/.github/workflows/publish-to-bcr.yml
@@ -1,0 +1,42 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Publish to BCR
+
+on:
+  # Automatic trigger when a tag is published
+  push:
+    tags:
+      - 'v*'
+  # Manual trigger for testing and initial setup
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name to publish (e.g., v1.0.0)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1
+    with:
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+      registry_fork: bazelbuild/bazel-central-registry
+      attest: false
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
#### Description

Add BCR workflow configuration for [Bazel Central Registry](https://github.com/bazelbuild/bazel-central-registry) publishing.

See [publish-to-bcr](https://github.com/bazel-contrib/publish-to-bcr)