### PR TITLE
Add IWYU pragmas to SDK headers

### DIFF
--- a/proxy_wasm_api.h
+++ b/proxy_wasm_api.h
@@ -21,6 +21,9 @@
 // NOLINT(namespace-envoy)
 #pragma once
 
+// IWYU pragma: private, include "proxy_wasm_intrinsics.h"
+// IWYU pragma: friend "proxy_wasm_.*"
+
 #ifdef PROXY_WASM_PROTOBUF
 #include "google/protobuf/message_lite.h"
 #endif

--- a/proxy_wasm_common.h
+++ b/proxy_wasm_common.h
@@ -21,6 +21,9 @@
 // NOLINT(namespace-envoy)
 #pragma once
 
+// IWYU pragma: private, include "proxy_wasm_intrinsics.h"
+// IWYU pragma: friend "proxy_wasm_.*"
+
 #include <cstdint>
 #include <string>
 

--- a/proxy_wasm_enums.h
+++ b/proxy_wasm_enums.h
@@ -21,6 +21,9 @@
 // NOLINT(namespace-envoy)
 #pragma once
 
+// IWYU pragma: private, include "proxy_wasm_intrinsics.h"
+// IWYU pragma: friend "proxy_wasm_.*"
+
 #include <cstdint>
 
 // Severity levels for logging operations.

--- a/proxy_wasm_externs.h
+++ b/proxy_wasm_externs.h
@@ -21,6 +21,9 @@
 // NOLINT(namespace-envoy)
 #pragma once
 
+// IWYU pragma: private, include "proxy_wasm_intrinsics.h"
+// IWYU pragma: friend "proxy_wasm_.*"
+
 #include <stddef.h>
 #include <stdint.h>
 

--- a/proxy_wasm_intrinsics.h
+++ b/proxy_wasm_intrinsics.h
@@ -29,6 +29,7 @@
 #define START_WASM_PLUGIN(_x)
 #define END_WASM_PLUGIN
 
+// IWYU pragma: begin_exports
 #include <cstdint>
 #include <string_view>
 #include <optional>
@@ -45,3 +46,4 @@
 #include "proxy_wasm_intrinsics_lite.pb.h"
 #endif
 #include "proxy_wasm_api.h"
+// IWYU pragma: end_exports

--- a/proxy_wasm_intrinsics_full.h
+++ b/proxy_wasm_intrinsics_full.h
@@ -22,4 +22,4 @@
 #pragma once
 
 #define PROXY_WASM_PROTOBUF_FULL 1
-#include "proxy_wasm_intrinsics.h"
+#include "proxy_wasm_intrinsics.h" // IWYU pragma: export

--- a/proxy_wasm_intrinsics_lite.h
+++ b/proxy_wasm_intrinsics_lite.h
@@ -22,4 +22,4 @@
 #pragma once
 
 #define PROXY_WASM_PROTOBUF_LITE 1
-#include "proxy_wasm_intrinsics.h"
+#include "proxy_wasm_intrinsics.h" // IWYU pragma: export


### PR DESCRIPTION
This directs clang to recommend including `proxy_wasm_intrinsics.h` rather than the individual headers, which is the pattern displayed by the examples.